### PR TITLE
[RFC] Fix X11 armada driver on hardened toolchain.

### DIFF
--- a/x11-drivers/xf86-video-armada-novena/xf86-video-armada-novena-0.0.1.16.ebuild
+++ b/x11-drivers/xf86-video-armada-novena/xf86-video-armada-novena-0.0.1.16.ebuild
@@ -2,9 +2,10 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header$
 
-EAPI="6"
+EAPI="5"
 
 inherit eutils versionator autotools
+inherit xorg-2
 
 DESCRIPTION="Accelerated video driver for the Novena's i.MX6"
 HOMEPAGE="https://github.com/xobs/xserver-xorg-video-armada"
@@ -47,6 +48,7 @@ src_prepare() {
 }
 
 src_configure() {
+	xorg-2_src_configure
 	econf 	--with-etnaviv-include=/usr/include \
 		--with-etnaviv-lib=/usr/lib \
 		--disable-vivante


### PR DESCRIPTION
Use the special eclass for xorg2 in the ebuild file.

--------
Using the xorg-2 eclass' configure function before running econf seems to fix the issue that I was having.  I tried several variations, such as running econf and then xorg-conf, running xorg-conf with the same arguments as econf, and this is the only option that worked.

This solution is weird (read: crappy) because it runs configure twice, but at least it works.